### PR TITLE
Revert 559840c

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -139,8 +139,7 @@ url-pretty: "www.crazyee.com"  # eg. "deanattali.com/beautiful-jekyll"
 staticman:
   repository : "hotsauce1861/hotsauce1861.github.io" # GitHub username/repository eg. "daattali/beautiful-jekyll"
   branch     : master # If you're not using `master` branch, then you also need to update the `branch` parameter in `staticman.yml`
-  endpoint   : "https://api.staticman.net/v3/entry/github/" # URL of your own deployment, with a trailing slash (will fallback to a public GitLab instance) eg. https://<your-api>/v3/entry/github/
-  # https://api.staticman.net/v1/webhook
+  endpoint   : "https://staticman3.herokuapp.com/v3/entry/github/" # URL of your own deployment, with a trailing slash (will fallback to a public GitLab instance) eg. https://<your-api>/v3/entry/github/
   reCaptcha:
     # reCaptcha for Staticman (OPTIONAL, but recommended for spam protection)
     # If you use reCaptcha, you must also set these parameters in staticman.yml


### PR DESCRIPTION
Staticman official instances are unavaible, as reported in https://github.com/eduardoboucas/staticman/issues/307

As reported in https://github.com/mmistakes/minimal-mistakes/issues/1438, when the blog title contains Chinese characters, the comment display won't work.  You may see the last comment in the linked GitHub issue to see the suggested solution.